### PR TITLE
Update electrs to version v0.8.10

### DIFF
--- a/bitcoind/Dockerfile
+++ b/bitcoind/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /root
 
 ENV BITCOIN_REPO=https://github.com/bitcoin/bitcoin.git
 ENV BITCOIN_BRANCH=master
-ENV BITCOIN_TAG=v0.21.0
+ENV BITCOIN_TAG=v0.21.1
 
 RUN apt-get update && \
     apt-get install git build-essential libtool autotools-dev automake pkg-config \

--- a/electrs/Dockerfile
+++ b/electrs/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y libllvm10 clang-10 libclang-common-10-dev curl cargo
 
-RUN cargo install --git https://github.com/romanz/electrs --bin electrs
+RUN cargo install --git https://github.com/romanz/electrs --tag v0.8.10 --bin electrs
 
-FROM bitcoindevkit/bitcoind:0.2.0
+FROM bitcoindevkit/bitcoind:0.3.0
 
 COPY --from=builder /root/.cargo/bin/electrs /root
 

--- a/esplora/Dockerfile
+++ b/esplora/Dockerfile
@@ -17,7 +17,7 @@ RUN git clone https://github.com/blockstream/electrs
 WORKDIR electrs
 RUN cargo build --release --bin electrs
 
-FROM bitcoindevkit/bitcoind:0.2.0
+FROM bitcoindevkit/bitcoind:0.3.0
 
 COPY --from=builder /root/electrs/target/release/electrs /root
 


### PR DESCRIPTION
Also in this PR:

Update bitcoindevkit/bitcoind:0.3.0 container to bitcoind to 0.21.1 and bitcoindevkit/electrs:0.3.0 and bitcoindevkit/esplora:0.3.0 containers to use bitcoindevkit/bitcoind:0.3.0.  