### PR TITLE
txid-fix popular addresses should be indexed in regtest mode

### DIFF
--- a/electrs/entrypoint.sh
+++ b/electrs/entrypoint.sh
@@ -15,4 +15,4 @@ ADDR=$(/root/bitcoin-cli -regtest -datadir=/root/.bitcoin -rpcwallet=bdk-test ge
 /root/bitcoin-cli -regtest -datadir=/root/.bitcoin generatetoaddress 150 $ADDR
 
 echo -e "\nStarting electrs node.\n"
-/root/electrs --network regtest --cookie-file /root/.bitcoin/regtest/.cookie -vvv --jsonrpc-import
+/root/electrs --network regtest --cookie-file /root/.bitcoin/regtest/.cookie --txid-limit 0 -vvv --jsonrpc-import


### PR DESCRIPTION
From `electrs` documentation,

```txt
 --txid-limit <txid_limit>
     Number of transactions to lookup before returning an error, to prevent "too popular" addresses from causing
     the RPC server to get stuck (0 - disable the limit) [default: 100]
```

This change also fixes https://github.com/bitcoindevkit/bdk/issues/406